### PR TITLE
fix: globbing

### DIFF
--- a/src/lib/EpubParser.ts
+++ b/src/lib/EpubParser.ts
@@ -97,7 +97,7 @@ export class EpubParser {
 		const parser = new xml2js.Parser();
 		const file = path.join(
 			this.tmpPath,
-			jetpack.find(this.tmpPath, { matching: `**/*.${suffix}` })[0]
+			jetpack.cwd(this.tmpPath).find({ matching: `**/*.${suffix}` })[0]
 		);
 		const data = jetpack.read(file);
 

--- a/src/lib/EpubParser.ts
+++ b/src/lib/EpubParser.ts
@@ -95,7 +95,7 @@ export class EpubParser {
 
 	async parseBySuffix(suffix: string): Promise<[string, any]> {
 		const parser = new xml2js.Parser();
-		const file = path.join(
+		const file = path.posix.join(
 			this.tmpPath,
 			jetpack.cwd(this.tmpPath).find({ matching: `**/*.${suffix}` })[0]
 		);
@@ -117,7 +117,7 @@ export class EpubParser {
 		const getToc = (navPoint, level) => {
 			const cpt = new Chapter(
 				navPoint.navLabel[0].text[0],
-				path.join(path.dirname(this.ncxFilePath), navPoint.content[0].$["src"]),
+				path.posix.join(path.dirname(this.ncxFilePath), navPoint.content[0].$["src"]),
 				navPoint["navPoint"]?.map((pt) => getToc(pt, level + 1)) ?? [],
 				level
 			);
@@ -137,7 +137,7 @@ export class EpubParser {
 		const hrefs: string[] = this.opfContent.package.manifest[0].item
 			.map((item) => item.$.href)
 			.filter((href) => [".htm", ".html", ".xhtml"].some((sx) => href.includes(sx)))
-			.map((href) => path.join(path.dirname(this.opfFilePath), href));
+			.map((href) => path.posix.join(path.dirname(this.opfFilePath), href));
 
 		// create a mapping from chapters index to hrefs index.
 		const indexs = [];
@@ -228,7 +228,7 @@ export class EpubParser {
 				["cover", "Cover"].some((sx) => item.$.id.includes(sx)) &&
 				["png", "jpg", "jpeg"].includes(path.extname(item.$.href).slice(1))
 		);
-		if (coverItem) this.coverPath = path.join(path.dirname(this.opfFilePath), coverItem.$.href);
+		if (coverItem) this.coverPath = path.posix.join(path.dirname(this.opfFilePath), coverItem.$.href);
 	}
 
 	async parseMeta() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import * as path from "path";
 import i18next from "i18next";
 import { resources, translationLanguage } from "./i18n/i18next";
 
+
 export default class EpubImporterPlugin extends Plugin {
 	vaultPath: string;
 	settings: EpubImporterSettings;
@@ -151,11 +152,11 @@ export default class EpubImporterPlugin extends Plugin {
 			tag,
 			granularity,
 		} = this.settings;
-		const folderPath = path.join(savePath, epubName);
+		const folderPath = path.posix.join(savePath, epubName);
 
-		if (jetpack.exists(path.join(this.vaultPath, folderPath))) {
+		if (jetpack.exists(path.posix.join(this.vaultPath, folderPath))) {
 			if (this.settings.removeDuplicateFolders) {
-				jetpack.remove(path.join(this.vaultPath, folderPath));
+				jetpack.remove(path.posix.join(this.vaultPath, folderPath));
 			} else {
 				new Notice("Duplicate folder already exists.");
 				return;
@@ -190,7 +191,7 @@ export default class EpubImporterPlugin extends Plugin {
 			}
 			let notePath = folderPath;
 			if (this.settings.oneFolder) {
-				notePath = path.join(folderPath, epubName);
+				notePath = path.posix.join(folderPath, epubName);
 			}
 			await this.app.vault.create(
 				notePath + ".md",
@@ -216,7 +217,7 @@ export default class EpubImporterPlugin extends Plugin {
 			};
 			getPaths(cpt);
 			if (cpt.level < granularity && cpt.subItems.length != 0) paths.push(cpt.name);
-			const notePath = path.join(folderPath, ...paths);
+			const notePath = path.posix.join(folderPath, ...paths);
 			await this.app.vault.createFolder(path.dirname(notePath)).catch(() => {/**/});
 
 			let content = "";
@@ -241,7 +242,7 @@ export default class EpubImporterPlugin extends Plugin {
 
 		this.BookNote = tFrontmatter(this.properties) + "\n" + this.BookNote;
 		await this.app.vault.create(
-			path.join(
+			path.posix.join(
 				folderPath,
 				templateWithVariables(this.settings.mocName, { bookName: epubName })
 			) + ".md",
@@ -253,16 +254,16 @@ export default class EpubImporterPlugin extends Plugin {
 	}
 
 	copyImages() {
-		const imagesPath = path.join(this.vaultPath, this.assetsPath);
+		const imagesPath = path.posix.join(this.vaultPath, this.assetsPath);
 		jetpack
 			.find(this.parser.tmpPath, { matching: ["*.jpg", "*.jpeg", "*.png"] })
 			.forEach((file) =>
-				jetpack.copy(file, path.join(imagesPath, path.basename(file)), {
+				jetpack.copy(file, path.posix.join(imagesPath, path.basename(file)), {
 					overwrite: true,
 				})
 			);
 		if (this.parser.coverPath) {
-			this.properties.cover = path.join(this.assetsPath, path.basename(this.parser.coverPath));
+			this.properties.cover = path.posix.join(this.assetsPath, path.basename(this.parser.coverPath));
 		}
 	}
 


### PR DESCRIPTION
0.3.6 改了glob， 生成的路径会多一个 `/TEMP`

0.3.6: `~\AppData\Local\Temp\Temp\edcd9c74b34ddde01fc522d50de0e3e1\OEBPS\content.opf`
0.3.5: `~\AppData\Local\Temp\edcd9c74b34ddde01fc522d50de0e3e1\OEBPS\content.opf`

另外原来生成的目录路径用`\`分隔，obsidian不认，我全改成`/`了

fix #87 