### PR TITLE
feat(parser): normalize sections filenames

### DIFF
--- a/src/lib/EpubParser.ts
+++ b/src/lib/EpubParser.ts
@@ -6,23 +6,22 @@ import extract from "extract-zip";
 import jetpack from "fs-jetpack";
 import * as path from "path";
 import * as xml2js from "xml2js";
-import { normalize } from "../utils/utils";
 
 export class Section {
-    name: string;
-    url: string;
-    urlPath: string;
-    urlHref: string;
-    html: string;
+	name: string;
+	url: string;
+	urlPath: string;
+	urlHref: string;
+	html: string;
 
-    constructor(name: string, url: string) {
-        this.name = normalize(name);
-        this.url = url;
-        const [urlPath, urlHref] = url.split("#");
-        this.urlPath = urlPath;
-        this.urlHref = urlHref ?? "";
-        this.html = "";
-    }
+	constructor(name: string, url: string) {
+		this.name = name;
+		this.url = url;
+		const [urlPath, urlHref] = url.split("#");
+		this.urlPath = urlPath;
+		this.urlHref = urlHref ?? "";
+		this.html = "";
+	}
 }
 
 export class Chapter {
@@ -183,7 +182,7 @@ export class EpubParser {
 			this.sections
 				.filter((st) => st.urlPath == url)
 				.forEach((st) => {
-					file.names.push(normalize(st.name ? path.basename(st.name) : null));
+					file.names.push(st.name ? path.basename(st.name) : null);
 					file.hrefs.push(st.urlHref);
 				});
 			try {

--- a/src/lib/EpubParser.ts
+++ b/src/lib/EpubParser.ts
@@ -6,22 +6,23 @@ import extract from "extract-zip";
 import jetpack from "fs-jetpack";
 import * as path from "path";
 import * as xml2js from "xml2js";
+import { normalize } from "../utils/utils";
 
 export class Section {
-	name: string;
-	url: string;
-	urlPath: string;
-	urlHref: string;
-	html: string;
+    name: string;
+    url: string;
+    urlPath: string;
+    urlHref: string;
+    html: string;
 
-	constructor(name: string, url: string) {
-		this.name = name;
-		this.url = url;
-		const [urlPath, urlHref] = url.split("#");
-		this.urlPath = urlPath;
-		this.urlHref = urlHref ?? "";
-		this.html = "";
-	}
+    constructor(name: string, url: string) {
+        this.name = normalize(name);
+        this.url = url;
+        const [urlPath, urlHref] = url.split("#");
+        this.urlPath = urlPath;
+        this.urlHref = urlHref ?? "";
+        this.html = "";
+    }
 }
 
 export class Chapter {
@@ -182,7 +183,7 @@ export class EpubParser {
 			this.sections
 				.filter((st) => st.urlPath == url)
 				.forEach((st) => {
-					file.names.push(st.name ? path.basename(st.name) : null);
+					file.names.push(normalize(st.name ? path.basename(st.name) : null));
 					file.hrefs.push(st.urlHref);
 				});
 			try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -219,7 +219,7 @@ export default class EpubImporterPlugin extends Plugin {
 			getPaths(cpt);
 			if (cpt.level < granularity && cpt.subItems.length != 0)
 				paths.push(normalize(cpt.name));
-			const notePath = path.posix.join(folderPath, ...paths);
+			const notePath = path.posix.join(folderPath, ...paths.map(normalize));
 			await this.app.vault.createFolder(path.dirname(notePath)).catch(() => {
 				/**/
 			});


### PR DESCRIPTION
This is a small fix for an issue where section files could not be created due to illegal characters in the file name.