### PR TITLE
feat: add support for Japanese ruby annotations in EPUB import

### DIFF
--- a/src/core/TurndownService.ts
+++ b/src/core/TurndownService.ts
@@ -37,6 +37,38 @@ export const create = (assetsPath: string, imageFormat: string): TurndownService
     httpLinks: {
       filter: (node) => node.nodeName === "A" && node.getAttribute("href")?.startsWith("http"),
       replacement: (_, node) => `[${node.textContent}](${node.getAttribute("href")})`
+    },// 新增规则：处理ruby标签
+    ruby: {
+      filter: "ruby",
+      replacement: (content, node) => {
+        // 获取基础文本（不包括rt标签）
+        const baseText = Array.from(node.childNodes)
+          .filter(child => 
+            child.nodeType === Node.TEXT_NODE || 
+            (child.nodeType === Node.ELEMENT_NODE && (child as Element).tagName.toLowerCase() !== "rt")
+          )
+          .map(child => {
+            if (child.nodeType === Node.TEXT_NODE) {
+              return child.textContent || "";
+            } else {
+              // 对于非rt元素节点，递归获取其文本内容
+              return (child as Element).textContent || "";
+            }
+          })
+          .join("");
+        
+        // 获取注音文本
+        const rtElement = node.querySelector("rt");
+        const rubyText = rtElement ? rtElement.textContent || "" : "";
+        
+        // 转换为 {漢字|かんじ} 格式
+        return `{${baseText}|${rubyText}}`;
+      }
+    },
+    // 新增规则：处理rt标签（使其不产生任何输出）
+    rt: {
+      filter: "rt",
+      replacement: () => ""
     }
   };
 


### PR DESCRIPTION
### 解决的问题

当前 EPUB 导入插件在处理日文书籍时不会处理 `<ruby>` 标签，导致注音信息完全丢失。这严重影响了日文书籍的阅读体验，因为注音（振假名）是日文文本的重要组成部分。

### 解决方案
在 `TurndownService.ts` 中添加了两个新的转换规则：
1. **ruby 规则**：将 `<ruby>漢字<rt>かんじ</rt></ruby>` 转换为 `{漢字|かんじ}` 格式
2. **rt 规则**：确保 `<rt>` 标签不会产生冗余输出

### 依赖说明
此功能需要配合 [Japanese Novel Ruby](https://github.com/k-quels/japanese-novel-ruby) Obsidian 插件使用。该插件负责渲染 `{漢字|かんじ}` 格式的注音，而本修改只负责将 EPUB 中的 ruby 标签转换为兼容格式。

### 效果对比
**修复前**：  
日文 EPUB 中的注音完全丢失，只显示基础汉字
**修复后**：  
<img width="632" height="116" alt="image" src="https://github.com/user-attachments/assets/99d1dda1-3075-4b49-aae5-8228dad4a39c" />

_注音正确显示（需要 Japanese Novel Ruby 插件）_

### 代码变更
- 在 `TurndownService.ts` 中添加了两个新的转换规则
- 保持了对现有功能的完全兼容性
- 遵循了项目的代码风格和架构

### 测试情况
- 测试了包含 ruby 标签的日文 EPUB 文件
- 确认转换后的格式与 Japanese Novel Ruby 插件兼容
- 验证了不影响其他 HTML 元素的正常转换
- 确保没有引入回归问题