### PR TITLE
fix: make library sync import concurrency configurable

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -11,6 +11,8 @@
   "Library": "The plugin will search for .epub files from these paths (absolute path).",
   "byDrag_o": "Import by drag",
   "byDrag": "Import .epub file by drag it to obsidian vault. The .epub  file will be deleted after importing.",
+  "Sync_import_concurrency_o": "Batch import concurrency",
+  "Sync_import_concurrency": "How many books to import at once when syncing libraries. Set 1 for strict serial import.",
   "storage": "Storage",
   "Save_path_o": "Save_path",
   "Save_path": "The plugin will save the imported book to this path (relative path).",

--- a/src/i18n/locales/zh-cn.json
+++ b/src/i18n/locales/zh-cn.json
@@ -11,6 +11,8 @@
   "Library": "该插件将从这些路径中搜索 .epub 文件(绝对路径)。",
   "byDrag_o": "通过拖拽导入",
   "byDrag": "将.epub文件拖拽到obsidian库中来导入它。导入后将删除该.epub文件。",
+  "Sync_import_concurrency_o": "批量导入并发数",
+  "Sync_import_concurrency": "同步书库时同时导入的书籍数量。设为 1 可强制串行导入。",
   "storage": "存储",
   "Save_path_o": "保存路径",
   "Save_path": "导入的epub将会被保存到该路径(相对路径)。",

--- a/src/main.ts
+++ b/src/main.ts
@@ -179,10 +179,28 @@ export default class EpubImporterPlugin extends Plugin {
 		if (!libraries.length) return this.showNotice(i18next.t("translation:no libraries"));
 
 		const epubs = libraries.flatMap((lib) => jetpack.find(lib, { matching: "**/**.epub" }));
-
-		await Promise.all(epubs.map((epub) => this.epubProcessor.importEpub(jetpack.path(epub))));
+		await this.importEpubsWithConcurrency(epubs);
 
 		this.showSyncResult(epubs.length);
+	}
+
+	private getSyncImportConcurrency() {
+		const raw = Math.floor(this.settings.syncImportConcurrency || 3);
+		return Math.max(1, raw);
+	}
+
+	private async importEpubsWithConcurrency(epubs: string[]) {
+		if (!epubs.length) return;
+		const concurrency = Math.min(this.getSyncImportConcurrency(), epubs.length);
+		let index = 0;
+		const worker = async () => {
+			while (index < epubs.length) {
+				const epub = epubs[index++];
+				const processor = new EpubProcessor(this.app, this.settings, this.vaultPath);
+				await processor.importEpub(jetpack.path(epub));
+			}
+		};
+		await Promise.all(Array.from({ length: concurrency }, worker));
 	}
 
 	private showSyncResult(count: number) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -185,7 +185,7 @@ export default class EpubImporterPlugin extends Plugin {
 	}
 
 	private getSyncImportConcurrency() {
-		const raw = Math.floor(this.settings.syncImportConcurrency || 3);
+		const raw = Math.floor(this.settings.syncImportConcurrency ?? 3);
 		return Math.max(1, raw);
 	}
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -2,6 +2,7 @@ export interface EpubImporterSettings {
 	tag: string;
 	libraries: string[];
 	byDrag: boolean;
+	syncImportConcurrency: number;
 	savePath: string;
 	assetsPath: string;
 	backupPath: string;
@@ -22,6 +23,7 @@ export const DEFAULT_SETTINGS: EpubImporterSettings = {
 	tag: "book",
 	libraries: [],
 	byDrag: false,
+	syncImportConcurrency: 3,
 	savePath: "",
 	assetsPath: "{{savePath}}/{{bookName}}/images",
 	backupPath: "",

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -44,6 +44,19 @@ export class EpubImporterSettingsTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				});
 			});
+		new Setting(containerEl)
+			.setName(i18next.t("translation:Sync_import_concurrency_o"))
+			.setDesc(i18next.t("translation:Sync_import_concurrency"))
+			.addSlider((slider) => {
+				slider
+					.setLimits(1, 10, 1)
+					.setDynamicTooltip()
+					.setValue(this.plugin.settings.syncImportConcurrency)
+					.onChange(async (value) => {
+						this.plugin.settings.syncImportConcurrency = value;
+						await this.plugin.saveSettings();
+					});
+			});
 		new Setting(containerEl).setName(i18next.t("translation:storage")).setHeading();
 		new Setting(containerEl)
 			.setName(i18next.t("translation:Save_path_o"))


### PR DESCRIPTION
## Summary
- Fix batch library sync import state collision by avoiding a shared `EpubProcessor` instance across simultaneous imports.
- Add a new setting `syncImportConcurrency` with default value `3`.
- Expose the setting in GUI as a slider (`1-10`), where `1` means strict serial import.
- Add i18n strings for the new setting in English and Simplified Chinese.

## Changes
- `src/main.ts`
  - Replace shared `Promise.all(...this.epubProcessor.importEpub...)` call with `importEpubsWithConcurrency`.
  - Use one `EpubProcessor` instance per book import task.
  - Add safe concurrency normalization (`>= 1`, default fallback `3`).
- `src/settings/settings.ts`
  - Add `syncImportConcurrency: number` to settings interface.
  - Add `syncImportConcurrency: 3` to defaults.
- `src/settings/settingsTab.ts`
  - Add settings slider for batch import concurrency.
- `src/i18n/locales/en.json`
- `src/i18n/locales/zh-cn.json`
  - Add translation keys for the new setting.

## Motivation
Single-book import was stable, while multi-book sync could fail due to concurrent mutation of shared processor state (`parser`, `properties`, `bookNote`, `assetsPath`).
